### PR TITLE
try to support simple pages as markup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,11 @@
         $filename = preg_replace("/\.html$/i", "", $file);
         $title = preg_replace("/\-/i", " ", $filename);
         $title = ucwords($title);
-        echo '<li><a href="#sg-'.$filename.'">'.$title.'</a></li>';
+        if($type === 'pages'):
+          echo '<li><a href="markup/pages/'.$filename.'.html" target="_blank">'.$title.'</a></li>';
+        else:
+          echo '<li><a href="#sg-'.$filename.'">'.$title.'</a></li>';
+        endif;
     endforeach;
   }
 

--- a/index.php
+++ b/index.php
@@ -47,6 +47,12 @@
         </ul>
       </div>
       <div class="sg-nav-group">
+        <h2 class="sg-h2 sg-subnav-title">Pages</h2>
+        <ul class="sg-navlist">
+          <?php listMarkupAsListItems('pages'); ?>
+        </ul>
+      </div>
+      <div class="sg-nav-group">
         <h2 class="sg-h2 sg-subnav-title">Base HTML</h2>
         <ul class="sg-navlist">
           <?php listMarkupAsListItems('base'); ?>
@@ -183,4 +189,3 @@
   <script src="js/sg-scripts.js"></script>
 </body>
 </html>
-

--- a/markup/pages/bootstrap-login.html
+++ b/markup/pages/bootstrap-login.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Bootstrap - Login page example</title>
+
+    <!-- Bootstrap -->
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+    <!-- Optional theme -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+
+    <style>
+    body {
+      padding-top: 40px;
+      padding-bottom: 40px;
+      background-color: #eee;
+    }
+
+    .form-signin {
+      max-width: 330px;
+      padding: 15px;
+      margin: 0 auto;
+    }
+    .form-signin .form-signin-heading,
+    .form-signin .checkbox {
+      margin-bottom: 10px;
+    }
+    .form-signin .checkbox {
+      font-weight: normal;
+    }
+    .form-signin .form-control {
+      position: relative;
+      height: auto;
+      -webkit-box-sizing: border-box;
+         -moz-box-sizing: border-box;
+              box-sizing: border-box;
+      padding: 10px;
+      font-size: 16px;
+    }
+    .form-signin .form-control:focus {
+      z-index: 2;
+    }
+    .form-signin input[type="email"] {
+      margin-bottom: -1px;
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+    .form-signin input[type="password"] {
+      margin-bottom: 10px;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+    </style>
+
+  </head>
+  <body>
+
+
+    <div class="container">
+
+     <form class="form-signin">
+       <h2 class="form-signin-heading">Please sign in</h2>
+       <label for="inputEmail" class="sr-only">Email address</label>
+       <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
+       <label for="inputPassword" class="sr-only">Password</label>
+       <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
+       <div class="checkbox">
+         <label>
+           <input type="checkbox" value="remember-me"> Remember me
+         </label>
+       </div>
+       <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+     </form>
+
+   </div> <!-- /container -->
+
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
I've just added a section named "pages" as a markup type, thinking this will be needed when people want some examples for integrate solution out of patterns and base HTML/CSS.

You may see the demo from [home page > Pages > Bootstrap Login] over local styleguide site.

You may want to merge the code changes if it meets your purpose to this github repository. 

Regards,
Xiaoqiang from China
